### PR TITLE
oidc login error fixed

### DIFF
--- a/kubeclient/pool.go
+++ b/kubeclient/pool.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 var errUnknownContext = errors.New("unknown context")


### PR DESCRIPTION
for fix oidc  user login

{"context":"xxxxxxx","error":"couldn't create dynamic client for given config: coulddynamic client for given config: no Auth Provider found for name \"oidc\"","level":"warning","msg":"couldn't at to the pool","time":"2024-05-16T11:29:07+08:00"}
